### PR TITLE
Journal search with '&' queries

### DIFF
--- a/external-scripts/Sharepoint-journal-search.html
+++ b/external-scripts/Sharepoint-journal-search.html
@@ -1,7 +1,7 @@
 <script type="text/javascript">  
 function searchPrimoJournal() {
   
-  var searchStringTmp = document.getElementById("primoQueryJournalTemp").value.replace(/[,]/g, " ");
+  var searchStringTmp = document.getElementById("primoQueryJournalTemp").value.replace(/[,]/g, " ").replace("&", "%26");
   var searchString="any,contains," + searchStringTmp;
   var url="https://i-share-dpu.primo.exlibrisgroup.com/discovery/jsearch?";
   var vid="01CARLI_DPU:CARLI_DPU";


### PR DESCRIPTION
Fixed '&' issue with journal search by replacing '&' with '%26' in the searchStringTmp variable. If there are issues with other symbols there might be a neater way to fix it rather than just chaining a bunch of replacements, but this works in the meantime.